### PR TITLE
Added new icons and simplified common CSS code

### DIFF
--- a/font-awesome-ionic-tabs.css
+++ b/font-awesome-ionic-tabs.css
@@ -35,35 +35,1910 @@ To add more icons:
   text-rendering: auto;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+}
 
-.ion-tab-fa-anchor:before {
-  content: "\f13d"; }
-
-.ion-tab-fa-tags:before {
-  content: "\f02c"; }
-
-.ion-tab-fa-list:before {
-  content: "\f03a"; }
-
+.ion-tab-fa-glass:before {
+  content: "\f000";
+}
+.ion-tab-fa-music:before {
+  content: "\f001";
+}
+.ion-tab-fa-search:before {
+  content: "\f002";
+}
+.ion-tab-fa-envelope-o:before {
+  content: "\f003";
+}
+.ion-tab-fa-heart:before {
+  content: "\f004";
+}
+.ion-tab-fa-star:before {
+  content: "\f005";
+}
+.ion-tab-fa-star-o:before {
+  content: "\f006";
+}
 .ion-tab-fa-user:before {
-  content: "\f007"; }
-
-.ion-tab-fa-users:before {
-  content: "\f0c0"; }
-
-.ion-tab-fa-comments:before {
-  content: "\f086"; }
-
-.ion-tab-fa-cog:before,
-.ion-tab-fa-gear:before {
-  content: "\f013"; }
-
-.ion-tab-fa-info:before {
-  content: "\f05a"; }
-
+  content: "\f007";
+}
+.ion-tab-fa-film:before {
+  content: "\f008";
+}
+.ion-tab-fa-th-large:before {
+  content: "\f009";
+}
+.ion-tab-fa-th:before {
+  content: "\f00a";
+}
+.ion-tab-fa-th-list:before {
+  content: "\f00b";
+}
+.ion-tab-fa-check:before {
+  content: "\f00c";
+}
+.fa-remove:before,
+.fa-close:before,
+.ion-tab-fa-times:before {
+  content: "\f00d";
+}
+.ion-tab-fa-search-plus:before {
+  content: "\f00e";
+}
+.ion-tab-fa-search-minus:before {
+  content: "\f010";
+}
+.ion-tab-fa-power-off:before {
+  content: "\f011";
+}
+.ion-tab-fa-signal:before {
+  content: "\f012";
+}
+.fa-gear:before,
+.ion-tab-fa-cog:before {
+  content: "\f013";
+}
+.ion-tab-fa-trash-o:before {
+  content: "\f014";
+}
+.ion-tab-fa-home:before {
+  content: "\f015";
+}
+.ion-tab-fa-file-o:before {
+  content: "\f016";
+}
+.ion-tab-fa-clock-o:before {
+  content: "\f017";
+}
+.ion-tab-fa-road:before {
+  content: "\f018";
+}
+.ion-tab-fa-download:before {
+  content: "\f019";
+}
+.ion-tab-fa-arrow-circle-o-down:before {
+  content: "\f01a";
+}
+.ion-tab-fa-arrow-circle-o-up:before {
+  content: "\f01b";
+}
+.ion-tab-fa-inbox:before {
+  content: "\f01c";
+}
+.ion-tab-fa-play-circle-o:before {
+  content: "\f01d";
+}
+.fa-rotate-right:before,
+.ion-tab-fa-repeat:before {
+  content: "\f01e";
+}
+.ion-tab-fa-refresh:before {
+  content: "\f021";
+}
+.ion-tab-fa-list-alt:before {
+  content: "\f022";
+}
+.ion-tab-fa-lock:before {
+  content: "\f023";
+}
+.ion-tab-fa-flag:before {
+  content: "\f024";
+}
+.ion-tab-fa-headphones:before {
+  content: "\f025";
+}
+.ion-tab-fa-volume-off:before {
+  content: "\f026";
+}
+.ion-tab-fa-volume-down:before {
+  content: "\f027";
+}
+.ion-tab-fa-volume-up:before {
+  content: "\f028";
+}
+.ion-tab-fa-qrcode:before {
+  content: "\f029";
+}
+.ion-tab-fa-barcode:before {
+  content: "\f02a";
+}
+.ion-tab-fa-tag:before {
+  content: "\f02b";
+}
+.ion-tab-fa-tags:before {
+  content: "\f02c";
+}
+.ion-tab-fa-book:before {
+  content: "\f02d";
+}
+.ion-tab-fa-bookmark:before {
+  content: "\f02e";
+}
+.ion-tab-fa-print:before {
+  content: "\f02f";
+}
+.ion-tab-fa-camera:before {
+  content: "\f030";
+}
+.ion-tab-fa-font:before {
+  content: "\f031";
+}
+.ion-tab-fa-bold:before {
+  content: "\f032";
+}
+.ion-tab-fa-italic:before {
+  content: "\f033";
+}
+.ion-tab-fa-text-height:before {
+  content: "\f034";
+}
+.ion-tab-fa-text-width:before {
+  content: "\f035";
+}
+.ion-tab-fa-align-left:before {
+  content: "\f036";
+}
+.ion-tab-fa-align-center:before {
+  content: "\f037";
+}
+.ion-tab-fa-align-right:before {
+  content: "\f038";
+}
+.ion-tab-fa-align-justify:before {
+  content: "\f039";
+}
+.ion-tab-fa-list:before {
+  content: "\f03a";
+}
+.fa-dedent:before,
+.ion-tab-fa-outdent:before {
+  content: "\f03b";
+}
+.ion-tab-fa-indent:before {
+  content: "\f03c";
+}
+.ion-tab-fa-video-camera:before {
+  content: "\f03d";
+}
+.fa-photo:before,
+.fa-image:before,
+.ion-tab-fa-picture-o:before {
+  content: "\f03e";
+}
+.ion-tab-fa-pencil:before {
+  content: "\f040";
+}
+.ion-tab-fa-map-marker:before {
+  content: "\f041";
+}
+.ion-tab-fa-adjust:before {
+  content: "\f042";
+}
+.ion-tab-fa-tint:before {
+  content: "\f043";
+}
+.fa-edit:before,
+.ion-tab-fa-pencil-square-o:before {
+  content: "\f044";
+}
+.ion-tab-fa-share-square-o:before {
+  content: "\f045";
+}
+.ion-tab-fa-check-square-o:before {
+  content: "\f046";
+}
+.ion-tab-fa-arrows:before {
+  content: "\f047";
+}
+.ion-tab-fa-step-backward:before {
+  content: "\f048";
+}
+.ion-tab-fa-fast-backward:before {
+  content: "\f049";
+}
+.ion-tab-fa-backward:before {
+  content: "\f04a";
+}
+.ion-tab-fa-play:before {
+  content: "\f04b";
+}
+.ion-tab-fa-pause:before {
+  content: "\f04c";
+}
+.ion-tab-fa-stop:before {
+  content: "\f04d";
+}
+.ion-tab-fa-forward:before {
+  content: "\f04e";
+}
+.ion-tab-fa-fast-forward:before {
+  content: "\f050";
+}
+.ion-tab-fa-step-forward:before {
+  content: "\f051";
+}
+.ion-tab-fa-eject:before {
+  content: "\f052";
+}
+.ion-tab-fa-chevron-left:before {
+  content: "\f053";
+}
+.ion-tab-fa-chevron-right:before {
+  content: "\f054";
+}
+.ion-tab-fa-plus-circle:before {
+  content: "\f055";
+}
+.ion-tab-fa-minus-circle:before {
+  content: "\f056";
+}
+.ion-tab-fa-times-circle:before {
+  content: "\f057";
+}
+.ion-tab-fa-check-circle:before {
+  content: "\f058";
+}
+.ion-tab-fa-question-circle:before {
+  content: "\f059";
+}
+.ion-tab-fa-info-circle:before {
+  content: "\f05a";
+}
+.ion-tab-fa-crosshairs:before {
+  content: "\f05b";
+}
+.ion-tab-fa-times-circle-o:before {
+  content: "\f05c";
+}
+.ion-tab-fa-check-circle-o:before {
+  content: "\f05d";
+}
+.ion-tab-fa-ban:before {
+  content: "\f05e";
+}
+.ion-tab-fa-arrow-left:before {
+  content: "\f060";
+}
+.ion-tab-fa-arrow-right:before {
+  content: "\f061";
+}
+.ion-tab-fa-arrow-up:before {
+  content: "\f062";
+}
+.ion-tab-fa-arrow-down:before {
+  content: "\f063";
+}
+.fa-mail-forward:before,
+.ion-tab-fa-share:before {
+  content: "\f064";
+}
+.ion-tab-fa-expand:before {
+  content: "\f065";
+}
+.ion-tab-fa-compress:before {
+  content: "\f066";
+}
+.ion-tab-fa-plus:before {
+  content: "\f067";
+}
+.ion-tab-fa-minus:before {
+  content: "\f068";
+}
+.ion-tab-fa-asterisk:before {
+  content: "\f069";
+}
+.ion-tab-fa-exclamation-circle:before {
+  content: "\f06a";
+}
+.ion-tab-fa-gift:before {
+  content: "\f06b";
+}
+.ion-tab-fa-leaf:before {
+  content: "\f06c";
+}
+.ion-tab-fa-fire:before {
+  content: "\f06d";
+}
+.ion-tab-fa-eye:before {
+  content: "\f06e";
+}
+.ion-tab-fa-eye-slash:before {
+  content: "\f070";
+}
+.fa-warning:before,
+.ion-tab-fa-exclamation-triangle:before {
+  content: "\f071";
+}
+.ion-tab-fa-plane:before {
+  content: "\f072";
+}
 .ion-tab-fa-calendar:before {
-  content: "\f073"; }
-
+  content: "\f073";
+}
+.ion-tab-fa-random:before {
+  content: "\f074";
+}
+.ion-tab-fa-comment:before {
+  content: "\f075";
+}
+.ion-tab-fa-magnet:before {
+  content: "\f076";
+}
+.ion-tab-fa-chevron-up:before {
+  content: "\f077";
+}
+.ion-tab-fa-chevron-down:before {
+  content: "\f078";
+}
+.ion-tab-fa-retweet:before {
+  content: "\f079";
+}
+.ion-tab-fa-shopping-cart:before {
+  content: "\f07a";
+}
+.ion-tab-fa-folder:before {
+  content: "\f07b";
+}
+.ion-tab-fa-folder-open:before {
+  content: "\f07c";
+}
+.ion-tab-fa-arrows-v:before {
+  content: "\f07d";
+}
+.ion-tab-fa-arrows-h:before {
+  content: "\f07e";
+}
+.fa-bar-chart-o:before,
+.ion-tab-fa-bar-chart:before {
+  content: "\f080";
+}
+.ion-tab-fa-twitter-square:before {
+  content: "\f081";
+}
+.ion-tab-fa-facebook-square:before {
+  content: "\f082";
+}
+.ion-tab-fa-camera-retro:before {
+  content: "\f083";
+}
+.ion-tab-fa-key:before {
+  content: "\f084";
+}
+.fa-gears:before,
+.ion-tab-fa-cogs:before {
+  content: "\f085";
+}
+.ion-tab-fa-comments:before {
+  content: "\f086";
+}
+.ion-tab-fa-thumbs-o-up:before {
+  content: "\f087";
+}
+.ion-tab-fa-thumbs-o-down:before {
+  content: "\f088";
+}
+.ion-tab-fa-star-half:before {
+  content: "\f089";
+}
+.ion-tab-fa-heart-o:before {
+  content: "\f08a";
+}
+.ion-tab-fa-sign-out:before {
+  content: "\f08b";
+}
+.ion-tab-fa-linkedin-square:before {
+  content: "\f08c";
+}
+.ion-tab-fa-thumb-tack:before {
+  content: "\f08d";
+}
+.ion-tab-fa-external-link:before {
+  content: "\f08e";
+}
+.ion-tab-fa-sign-in:before {
+  content: "\f090";
+}
+.ion-tab-fa-trophy:before {
+  content: "\f091";
+}
+.ion-tab-fa-github-square:before {
+  content: "\f092";
+}
+.ion-tab-fa-upload:before {
+  content: "\f093";
+}
+.ion-tab-fa-lemon-o:before {
+  content: "\f094";
+}
+.ion-tab-fa-phone:before {
+  content: "\f095";
+}
+.ion-tab-fa-square-o:before {
+  content: "\f096";
+}
+.ion-tab-fa-bookmark-o:before {
+  content: "\f097";
+}
+.ion-tab-fa-phone-square:before {
+  content: "\f098";
+}
+.ion-tab-fa-twitter:before {
+  content: "\f099";
+}
+.fa-facebook-f:before,
+.ion-tab-fa-facebook:before {
+  content: "\f09a";
+}
+.ion-tab-fa-github:before {
+  content: "\f09b";
+}
+.ion-tab-fa-unlock:before {
+  content: "\f09c";
+}
+.ion-tab-fa-credit-card:before {
+  content: "\f09d";
+}
+.fa-feed:before,
+.ion-tab-fa-rss:before {
+  content: "\f09e";
+}
+.ion-tab-fa-hdd-o:before {
+  content: "\f0a0";
+}
+.ion-tab-fa-bullhorn:before {
+  content: "\f0a1";
+}
+.ion-tab-fa-bell:before {
+  content: "\f0f3";
+}
+.ion-tab-fa-certificate:before {
+  content: "\f0a3";
+}
+.ion-tab-fa-hand-o-right:before {
+  content: "\f0a4";
+}
+.ion-tab-fa-hand-o-left:before {
+  content: "\f0a5";
+}
+.ion-tab-fa-hand-o-up:before {
+  content: "\f0a6";
+}
+.ion-tab-fa-hand-o-down:before {
+  content: "\f0a7";
+}
+.ion-tab-fa-arrow-circle-left:before {
+  content: "\f0a8";
+}
+.ion-tab-fa-arrow-circle-right:before {
+  content: "\f0a9";
+}
+.ion-tab-fa-arrow-circle-up:before {
+  content: "\f0aa";
+}
+.ion-tab-fa-arrow-circle-down:before {
+  content: "\f0ab";
+}
+.ion-tab-fa-globe:before {
+  content: "\f0ac";
+}
+.ion-tab-fa-wrench:before {
+  content: "\f0ad";
+}
+.ion-tab-fa-tasks:before {
+  content: "\f0ae";
+}
+.ion-tab-fa-filter:before {
+  content: "\f0b0";
+}
+.ion-tab-fa-briefcase:before {
+  content: "\f0b1";
+}
+.ion-tab-fa-arrows-alt:before {
+  content: "\f0b2";
+}
+.fa-group:before,
+.ion-tab-fa-users:before {
+  content: "\f0c0";
+}
+.fa-chain:before,
+.ion-tab-fa-link:before {
+  content: "\f0c1";
+}
+.ion-tab-fa-cloud:before {
+  content: "\f0c2";
+}
+.ion-tab-fa-flask:before {
+  content: "\f0c3";
+}
+.fa-cut:before,
+.ion-tab-fa-scissors:before {
+  content: "\f0c4";
+}
+.fa-copy:before,
+.ion-tab-fa-files-o:before {
+  content: "\f0c5";
+}
+.ion-tab-fa-paperclip:before {
+  content: "\f0c6";
+}
+.fa-save:before,
+.ion-tab-fa-floppy-o:before {
+  content: "\f0c7";
+}
+.ion-tab-fa-square:before {
+  content: "\f0c8";
+}
+.fa-navicon:before,
+.fa-reorder:before,
+.ion-tab-fa-bars:before {
+  content: "\f0c9";
+}
+.ion-tab-fa-list-ul:before {
+  content: "\f0ca";
+}
+.ion-tab-fa-list-ol:before {
+  content: "\f0cb";
+}
+.ion-tab-fa-strikethrough:before {
+  content: "\f0cc";
+}
+.ion-tab-fa-underline:before {
+  content: "\f0cd";
+}
+.ion-tab-fa-table:before {
+  content: "\f0ce";
+}
+.ion-tab-fa-magic:before {
+  content: "\f0d0";
+}
+.ion-tab-fa-truck:before {
+  content: "\f0d1";
+}
+.ion-tab-fa-pinterest:before {
+  content: "\f0d2";
+}
+.ion-tab-fa-pinterest-square:before {
+  content: "\f0d3";
+}
+.ion-tab-fa-google-plus-square:before {
+  content: "\f0d4";
+}
+.ion-tab-fa-google-plus:before {
+  content: "\f0d5";
+}
+.ion-tab-fa-money:before {
+  content: "\f0d6";
+}
+.ion-tab-fa-caret-down:before {
+  content: "\f0d7";
+}
+.ion-tab-fa-caret-up:before {
+  content: "\f0d8";
+}
+.ion-tab-fa-caret-left:before {
+  content: "\f0d9";
+}
+.ion-tab-fa-caret-right:before {
+  content: "\f0da";
+}
+.ion-tab-fa-columns:before {
+  content: "\f0db";
+}
+.fa-unsorted:before,
+.ion-tab-fa-sort:before {
+  content: "\f0dc";
+}
+.fa-sort-down:before,
+.ion-tab-fa-sort-desc:before {
+  content: "\f0dd";
+}
+.fa-sort-up:before,
+.ion-tab-fa-sort-asc:before {
+  content: "\f0de";
+}
+.ion-tab-fa-envelope:before {
+  content: "\f0e0";
+}
+.ion-tab-fa-linkedin:before {
+  content: "\f0e1";
+}
+.fa-rotate-left:before,
+.ion-tab-fa-undo:before {
+  content: "\f0e2";
+}
+.fa-legal:before,
+.ion-tab-fa-gavel:before {
+  content: "\f0e3";
+}
+.fa-dashboard:before,
+.ion-tab-fa-tachometer:before {
+  content: "\f0e4";
+}
+.ion-tab-fa-comment-o:before {
+  content: "\f0e5";
+}
+.ion-tab-fa-comments-o:before {
+  content: "\f0e6";
+}
+.fa-flash:before,
+.ion-tab-fa-bolt:before {
+  content: "\f0e7";
+}
+.ion-tab-fa-sitemap:before {
+  content: "\f0e8";
+}
+.ion-tab-fa-umbrella:before {
+  content: "\f0e9";
+}
+.fa-paste:before,
+.ion-tab-fa-clipboard:before {
+  content: "\f0ea";
+}
+.ion-tab-fa-lightbulb-o:before {
+  content: "\f0eb";
+}
+.ion-tab-fa-exchange:before {
+  content: "\f0ec";
+}
+.ion-tab-fa-cloud-download:before {
+  content: "\f0ed";
+}
+.ion-tab-fa-cloud-upload:before {
+  content: "\f0ee";
+}
+.ion-tab-fa-user-md:before {
+  content: "\f0f0";
+}
+.ion-tab-fa-stethoscope:before {
+  content: "\f0f1";
+}
+.ion-tab-fa-suitcase:before {
+  content: "\f0f2";
+}
+.ion-tab-fa-bell-o:before {
+  content: "\f0a2";
+}
+.ion-tab-fa-coffee:before {
+  content: "\f0f4";
+}
+.ion-tab-fa-cutlery:before {
+  content: "\f0f5";
+}
+.ion-tab-fa-file-text-o:before {
+  content: "\f0f6";
+}
+.ion-tab-fa-building-o:before {
+  content: "\f0f7";
+}
+.ion-tab-fa-hospital-o:before {
+  content: "\f0f8";
+}
+.ion-tab-fa-ambulance:before {
+  content: "\f0f9";
+}
+.ion-tab-fa-medkit:before {
+  content: "\f0fa";
+}
+.ion-tab-fa-fighter-jet:before {
+  content: "\f0fb";
+}
+.ion-tab-fa-beer:before {
+  content: "\f0fc";
+}
+.ion-tab-fa-h-square:before {
+  content: "\f0fd";
+}
+.ion-tab-fa-plus-square:before {
+  content: "\f0fe";
+}
+.ion-tab-fa-angle-double-left:before {
+  content: "\f100";
+}
+.ion-tab-fa-angle-double-right:before {
+  content: "\f101";
+}
+.ion-tab-fa-angle-double-up:before {
+  content: "\f102";
+}
+.ion-tab-fa-angle-double-down:before {
+  content: "\f103";
+}
+.ion-tab-fa-angle-left:before {
+  content: "\f104";
+}
+.ion-tab-fa-angle-right:before {
+  content: "\f105";
+}
+.ion-tab-fa-angle-up:before {
+  content: "\f106";
+}
+.ion-tab-fa-angle-down:before {
+  content: "\f107";
+}
+.ion-tab-fa-desktop:before {
+  content: "\f108";
+}
+.ion-tab-fa-laptop:before {
+  content: "\f109";
+}
+.ion-tab-fa-tablet:before {
+  content: "\f10a";
+}
+.fa-mobile-phone:before,
+.ion-tab-fa-mobile:before {
+  content: "\f10b";
+}
+.ion-tab-fa-circle-o:before {
+  content: "\f10c";
+}
+.ion-tab-fa-quote-left:before {
+  content: "\f10d";
+}
+.ion-tab-fa-quote-right:before {
+  content: "\f10e";
+}
+.ion-tab-fa-spinner:before {
+  content: "\f110";
+}
+.ion-tab-fa-circle:before {
+  content: "\f111";
+}
+.fa-mail-reply:before,
+.ion-tab-fa-reply:before {
+  content: "\f112";
+}
+.ion-tab-fa-github-alt:before {
+  content: "\f113";
+}
+.ion-tab-fa-folder-o:before {
+  content: "\f114";
+}
+.ion-tab-fa-folder-open-o:before {
+  content: "\f115";
+}
+.ion-tab-fa-smile-o:before {
+  content: "\f118";
+}
+.ion-tab-fa-frown-o:before {
+  content: "\f119";
+}
+.ion-tab-fa-meh-o:before {
+  content: "\f11a";
+}
+.ion-tab-fa-gamepad:before {
+  content: "\f11b";
+}
+.ion-tab-fa-keyboard-o:before {
+  content: "\f11c";
+}
+.ion-tab-fa-flag-o:before {
+  content: "\f11d";
+}
+.ion-tab-fa-flag-checkered:before {
+  content: "\f11e";
+}
+.ion-tab-fa-terminal:before {
+  content: "\f120";
+}
+.ion-tab-fa-code:before {
+  content: "\f121";
+}
+.fa-mail-reply-all:before,
+.ion-tab-fa-reply-all:before {
+  content: "\f122";
+}
+.fa-star-half-empty:before,
+.fa-star-half-full:before,
+.ion-tab-fa-star-half-o:before {
+  content: "\f123";
+}
+.ion-tab-fa-location-arrow:before {
+  content: "\f124";
+}
+.ion-tab-fa-crop:before {
+  content: "\f125";
+}
+.ion-tab-fa-code-fork:before {
+  content: "\f126";
+}
+.fa-unlink:before,
+.ion-tab-fa-chain-broken:before {
+  content: "\f127";
+}
+.ion-tab-fa-question:before {
+  content: "\f128";
+}
+.ion-tab-fa-info:before {
+  content: "\f129";
+}
+.ion-tab-fa-exclamation:before {
+  content: "\f12a";
+}
+.ion-tab-fa-superscript:before {
+  content: "\f12b";
+}
+.ion-tab-fa-subscript:before {
+  content: "\f12c";
+}
+.ion-tab-fa-eraser:before {
+  content: "\f12d";
+}
+.ion-tab-fa-puzzle-piece:before {
+  content: "\f12e";
+}
+.ion-tab-fa-microphone:before {
+  content: "\f130";
+}
+.ion-tab-fa-microphone-slash:before {
+  content: "\f131";
+}
+.ion-tab-fa-shield:before {
+  content: "\f132";
+}
 .ion-tab-fa-calendar-o:before {
-  content: "\f133"; }
+  content: "\f133";
+}
+.ion-tab-fa-fire-extinguisher:before {
+  content: "\f134";
+}
+.ion-tab-fa-rocket:before {
+  content: "\f135";
+}
+.ion-tab-fa-maxcdn:before {
+  content: "\f136";
+}
+.ion-tab-fa-chevron-circle-left:before {
+  content: "\f137";
+}
+.ion-tab-fa-chevron-circle-right:before {
+  content: "\f138";
+}
+.ion-tab-fa-chevron-circle-up:before {
+  content: "\f139";
+}
+.ion-tab-fa-chevron-circle-down:before {
+  content: "\f13a";
+}
+.ion-tab-fa-html5:before {
+  content: "\f13b";
+}
+.ion-tab-fa-css3:before {
+  content: "\f13c";
+}
+.ion-tab-fa-anchor:before {
+  content: "\f13d";
+}
+.ion-tab-fa-unlock-alt:before {
+  content: "\f13e";
+}
+.ion-tab-fa-bullseye:before {
+  content: "\f140";
+}
+.ion-tab-fa-ellipsis-h:before {
+  content: "\f141";
+}
+.ion-tab-fa-ellipsis-v:before {
+  content: "\f142";
+}
+.ion-tab-fa-rss-square:before {
+  content: "\f143";
+}
+.ion-tab-fa-play-circle:before {
+  content: "\f144";
+}
+.ion-tab-fa-ticket:before {
+  content: "\f145";
+}
+.ion-tab-fa-minus-square:before {
+  content: "\f146";
+}
+.ion-tab-fa-minus-square-o:before {
+  content: "\f147";
+}
+.ion-tab-fa-level-up:before {
+  content: "\f148";
+}
+.ion-tab-fa-level-down:before {
+  content: "\f149";
+}
+.ion-tab-fa-check-square:before {
+  content: "\f14a";
+}
+.ion-tab-fa-pencil-square:before {
+  content: "\f14b";
+}
+.ion-tab-fa-external-link-square:before {
+  content: "\f14c";
+}
+.ion-tab-fa-share-square:before {
+  content: "\f14d";
+}
+.ion-tab-fa-compass:before {
+  content: "\f14e";
+}
+.fa-toggle-down:before,
+.ion-tab-fa-caret-square-o-down:before {
+  content: "\f150";
+}
+.fa-toggle-up:before,
+.ion-tab-fa-caret-square-o-up:before {
+  content: "\f151";
+}
+.fa-toggle-right:before,
+.ion-tab-fa-caret-square-o-right:before {
+  content: "\f152";
+}
+.fa-euro:before,
+.ion-tab-fa-eur:before {
+  content: "\f153";
+}
+.ion-tab-fa-gbp:before {
+  content: "\f154";
+}
+.fa-dollar:before,
+.ion-tab-fa-usd:before {
+  content: "\f155";
+}
+.fa-rupee:before,
+.ion-tab-fa-inr:before {
+  content: "\f156";
+}
+.fa-cny:before,
+.fa-rmb:before,
+.fa-yen:before,
+.ion-tab-fa-jpy:before {
+  content: "\f157";
+}
+.fa-ruble:before,
+.fa-rouble:before,
+.ion-tab-fa-rub:before {
+  content: "\f158";
+}
+.fa-won:before,
+.ion-tab-fa-krw:before {
+  content: "\f159";
+}
+.fa-bitcoin:before,
+.ion-tab-fa-btc:before {
+  content: "\f15a";
+}
+.ion-tab-fa-file:before {
+  content: "\f15b";
+}
+.ion-tab-fa-file-text:before {
+  content: "\f15c";
+}
+.ion-tab-fa-sort-alpha-asc:before {
+  content: "\f15d";
+}
+.ion-tab-fa-sort-alpha-desc:before {
+  content: "\f15e";
+}
+.ion-tab-fa-sort-amount-asc:before {
+  content: "\f160";
+}
+.ion-tab-fa-sort-amount-desc:before {
+  content: "\f161";
+}
+.ion-tab-fa-sort-numeric-asc:before {
+  content: "\f162";
+}
+.ion-tab-fa-sort-numeric-desc:before {
+  content: "\f163";
+}
+.ion-tab-fa-thumbs-up:before {
+  content: "\f164";
+}
+.ion-tab-fa-thumbs-down:before {
+  content: "\f165";
+}
+.ion-tab-fa-youtube-square:before {
+  content: "\f166";
+}
+.ion-tab-fa-youtube:before {
+  content: "\f167";
+}
+.ion-tab-fa-xing:before {
+  content: "\f168";
+}
+.ion-tab-fa-xing-square:before {
+  content: "\f169";
+}
+.ion-tab-fa-youtube-play:before {
+  content: "\f16a";
+}
+.ion-tab-fa-dropbox:before {
+  content: "\f16b";
+}
+.ion-tab-fa-stack-overflow:before {
+  content: "\f16c";
+}
+.ion-tab-fa-instagram:before {
+  content: "\f16d";
+}
+.ion-tab-fa-flickr:before {
+  content: "\f16e";
+}
+.ion-tab-fa-adn:before {
+  content: "\f170";
+}
+.ion-tab-fa-bitbucket:before {
+  content: "\f171";
+}
+.ion-tab-fa-bitbucket-square:before {
+  content: "\f172";
+}
+.ion-tab-fa-tumblr:before {
+  content: "\f173";
+}
+.ion-tab-fa-tumblr-square:before {
+  content: "\f174";
+}
+.ion-tab-fa-long-arrow-down:before {
+  content: "\f175";
+}
+.ion-tab-fa-long-arrow-up:before {
+  content: "\f176";
+}
+.ion-tab-fa-long-arrow-left:before {
+  content: "\f177";
+}
+.ion-tab-fa-long-arrow-right:before {
+  content: "\f178";
+}
+.ion-tab-fa-apple:before {
+  content: "\f179";
+}
+.ion-tab-fa-windows:before {
+  content: "\f17a";
+}
+.ion-tab-fa-android:before {
+  content: "\f17b";
+}
+.ion-tab-fa-linux:before {
+  content: "\f17c";
+}
+.ion-tab-fa-dribbble:before {
+  content: "\f17d";
+}
+.ion-tab-fa-skype:before {
+  content: "\f17e";
+}
+.ion-tab-fa-foursquare:before {
+  content: "\f180";
+}
+.ion-tab-fa-trello:before {
+  content: "\f181";
+}
+.ion-tab-fa-female:before {
+  content: "\f182";
+}
+.ion-tab-fa-male:before {
+  content: "\f183";
+}
+.fa-gittip:before,
+.ion-tab-fa-gratipay:before {
+  content: "\f184";
+}
+.ion-tab-fa-sun-o:before {
+  content: "\f185";
+}
+.ion-tab-fa-moon-o:before {
+  content: "\f186";
+}
+.ion-tab-fa-archive:before {
+  content: "\f187";
+}
+.ion-tab-fa-bug:before {
+  content: "\f188";
+}
+.ion-tab-fa-vk:before {
+  content: "\f189";
+}
+.ion-tab-fa-weibo:before {
+  content: "\f18a";
+}
+.ion-tab-fa-renren:before {
+  content: "\f18b";
+}
+.ion-tab-fa-pagelines:before {
+  content: "\f18c";
+}
+.ion-tab-fa-stack-exchange:before {
+  content: "\f18d";
+}
+.ion-tab-fa-arrow-circle-o-right:before {
+  content: "\f18e";
+}
+.ion-tab-fa-arrow-circle-o-left:before {
+  content: "\f190";
+}
+.fa-toggle-left:before,
+.ion-tab-fa-caret-square-o-left:before {
+  content: "\f191";
+}
+.ion-tab-fa-dot-circle-o:before {
+  content: "\f192";
+}
+.ion-tab-fa-wheelchair:before {
+  content: "\f193";
+}
+.ion-tab-fa-vimeo-square:before {
+  content: "\f194";
+}
+.fa-turkish-lira:before,
+.ion-tab-fa-try:before {
+  content: "\f195";
+}
+.ion-tab-fa-plus-square-o:before {
+  content: "\f196";
+}
+.ion-tab-fa-space-shuttle:before {
+  content: "\f197";
+}
+.ion-tab-fa-slack:before {
+  content: "\f198";
+}
+.ion-tab-fa-envelope-square:before {
+  content: "\f199";
+}
+.ion-tab-fa-wordpress:before {
+  content: "\f19a";
+}
+.ion-tab-fa-openid:before {
+  content: "\f19b";
+}
+.fa-institution:before,
+.fa-bank:before,
+.ion-tab-fa-university:before {
+  content: "\f19c";
+}
+.fa-mortar-board:before,
+.ion-tab-fa-graduation-cap:before {
+  content: "\f19d";
+}
+.ion-tab-fa-yahoo:before {
+  content: "\f19e";
+}
+.ion-tab-fa-google:before {
+  content: "\f1a0";
+}
+.ion-tab-fa-reddit:before {
+  content: "\f1a1";
+}
+.ion-tab-fa-reddit-square:before {
+  content: "\f1a2";
+}
+.ion-tab-fa-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+.ion-tab-fa-stumbleupon:before {
+  content: "\f1a4";
+}
+.ion-tab-fa-delicious:before {
+  content: "\f1a5";
+}
+.ion-tab-fa-digg:before {
+  content: "\f1a6";
+}
+.ion-tab-fa-pied-piper:before {
+  content: "\f1a7";
+}
+.ion-tab-fa-pied-piper-alt:before {
+  content: "\f1a8";
+}
+.ion-tab-fa-drupal:before {
+  content: "\f1a9";
+}
+.ion-tab-fa-joomla:before {
+  content: "\f1aa";
+}
+.ion-tab-fa-language:before {
+  content: "\f1ab";
+}
+.ion-tab-fa-fax:before {
+  content: "\f1ac";
+}
+.ion-tab-fa-building:before {
+  content: "\f1ad";
+}
+.ion-tab-fa-child:before {
+  content: "\f1ae";
+}
+.ion-tab-fa-paw:before {
+  content: "\f1b0";
+}
+.ion-tab-fa-spoon:before {
+  content: "\f1b1";
+}
+.ion-tab-fa-cube:before {
+  content: "\f1b2";
+}
+.ion-tab-fa-cubes:before {
+  content: "\f1b3";
+}
+.ion-tab-fa-behance:before {
+  content: "\f1b4";
+}
+.ion-tab-fa-behance-square:before {
+  content: "\f1b5";
+}
+.ion-tab-fa-steam:before {
+  content: "\f1b6";
+}
+.ion-tab-fa-steam-square:before {
+  content: "\f1b7";
+}
+.ion-tab-fa-recycle:before {
+  content: "\f1b8";
+}
+.fa-automobile:before,
+.ion-tab-fa-car:before {
+  content: "\f1b9";
+}
+.fa-cab:before,
+.ion-tab-fa-taxi:before {
+  content: "\f1ba";
+}
+.ion-tab-fa-tree:before {
+  content: "\f1bb";
+}
+.ion-tab-fa-spotify:before {
+  content: "\f1bc";
+}
+.ion-tab-fa-deviantart:before {
+  content: "\f1bd";
+}
+.ion-tab-fa-soundcloud:before {
+  content: "\f1be";
+}
+.ion-tab-fa-database:before {
+  content: "\f1c0";
+}
+.ion-tab-fa-file-pdf-o:before {
+  content: "\f1c1";
+}
+.ion-tab-fa-file-word-o:before {
+  content: "\f1c2";
+}
+.ion-tab-fa-file-excel-o:before {
+  content: "\f1c3";
+}
+.ion-tab-fa-file-powerpoint-o:before {
+  content: "\f1c4";
+}
+.fa-file-photo-o:before,
+.fa-file-picture-o:before,
+.ion-tab-fa-file-image-o:before {
+  content: "\f1c5";
+}
+.fa-file-zip-o:before,
+.ion-tab-fa-file-archive-o:before {
+  content: "\f1c6";
+}
+.fa-file-sound-o:before,
+.ion-tab-fa-file-audio-o:before {
+  content: "\f1c7";
+}
+.fa-file-movie-o:before,
+.ion-tab-fa-file-video-o:before {
+  content: "\f1c8";
+}
+.ion-tab-fa-file-code-o:before {
+  content: "\f1c9";
+}
+.ion-tab-fa-vine:before {
+  content: "\f1ca";
+}
+.ion-tab-fa-codepen:before {
+  content: "\f1cb";
+}
+.ion-tab-fa-jsfiddle:before {
+  content: "\f1cc";
+}
+.fa-life-bouy:before,
+.fa-life-buoy:before,
+.fa-life-saver:before,
+.fa-support:before,
+.ion-tab-fa-life-ring:before {
+  content: "\f1cd";
+}
+.ion-tab-fa-circle-o-notch:before {
+  content: "\f1ce";
+}
+.fa-ra:before,
+.ion-tab-fa-rebel:before {
+  content: "\f1d0";
+}
+.fa-ge:before,
+.ion-tab-fa-empire:before {
+  content: "\f1d1";
+}
+.ion-tab-fa-git-square:before {
+  content: "\f1d2";
+}
+.ion-tab-fa-git:before {
+  content: "\f1d3";
+}
+.fa-y-combinator-square:before,
+.fa-yc-square:before,
+.ion-tab-fa-hacker-news:before {
+  content: "\f1d4";
+}
+.ion-tab-fa-tencent-weibo:before {
+  content: "\f1d5";
+}
+.ion-tab-fa-qq:before {
+  content: "\f1d6";
+}
+.fa-wechat:before,
+.ion-tab-fa-weixin:before {
+  content: "\f1d7";
+}
+.fa-send:before,
+.ion-tab-fa-paper-plane:before {
+  content: "\f1d8";
+}
+.fa-send-o:before,
+.ion-tab-fa-paper-plane-o:before {
+  content: "\f1d9";
+}
+.ion-tab-fa-history:before {
+  content: "\f1da";
+}
+.ion-tab-fa-circle-thin:before {
+  content: "\f1db";
+}
+.ion-tab-fa-header:before {
+  content: "\f1dc";
+}
+.ion-tab-fa-paragraph:before {
+  content: "\f1dd";
+}
+.ion-tab-fa-sliders:before {
+  content: "\f1de";
+}
+.ion-tab-fa-share-alt:before {
+  content: "\f1e0";
+}
+.ion-tab-fa-share-alt-square:before {
+  content: "\f1e1";
+}
+.ion-tab-fa-bomb:before {
+  content: "\f1e2";
+}
+.fa-soccer-ball-o:before,
+.ion-tab-fa-futbol-o:before {
+  content: "\f1e3";
+}
+.ion-tab-fa-tty:before {
+  content: "\f1e4";
+}
+.ion-tab-fa-binoculars:before {
+  content: "\f1e5";
+}
+.ion-tab-fa-plug:before {
+  content: "\f1e6";
+}
+.ion-tab-fa-slideshare:before {
+  content: "\f1e7";
+}
+.ion-tab-fa-twitch:before {
+  content: "\f1e8";
+}
+.ion-tab-fa-yelp:before {
+  content: "\f1e9";
+}
+.ion-tab-fa-newspaper-o:before {
+  content: "\f1ea";
+}
+.ion-tab-fa-wifi:before {
+  content: "\f1eb";
+}
+.ion-tab-fa-calculator:before {
+  content: "\f1ec";
+}
+.ion-tab-fa-paypal:before {
+  content: "\f1ed";
+}
+.ion-tab-fa-google-wallet:before {
+  content: "\f1ee";
+}
+.ion-tab-fa-cc-visa:before {
+  content: "\f1f0";
+}
+.ion-tab-fa-cc-mastercard:before {
+  content: "\f1f1";
+}
+.ion-tab-fa-cc-discover:before {
+  content: "\f1f2";
+}
+.ion-tab-fa-cc-amex:before {
+  content: "\f1f3";
+}
+.ion-tab-fa-cc-paypal:before {
+  content: "\f1f4";
+}
+.ion-tab-fa-cc-stripe:before {
+  content: "\f1f5";
+}
+.ion-tab-fa-bell-slash:before {
+  content: "\f1f6";
+}
+.ion-tab-fa-bell-slash-o:before {
+  content: "\f1f7";
+}
+.ion-tab-fa-trash:before {
+  content: "\f1f8";
+}
+.ion-tab-fa-copyright:before {
+  content: "\f1f9";
+}
+.ion-tab-fa-at:before {
+  content: "\f1fa";
+}
+.ion-tab-fa-eyedropper:before {
+  content: "\f1fb";
+}
+.ion-tab-fa-paint-brush:before {
+  content: "\f1fc";
+}
+.ion-tab-fa-birthday-cake:before {
+  content: "\f1fd";
+}
+.ion-tab-fa-area-chart:before {
+  content: "\f1fe";
+}
+.ion-tab-fa-pie-chart:before {
+  content: "\f200";
+}
+.ion-tab-fa-line-chart:before {
+  content: "\f201";
+}
+.ion-tab-fa-lastfm:before {
+  content: "\f202";
+}
+.ion-tab-fa-lastfm-square:before {
+  content: "\f203";
+}
+.ion-tab-fa-toggle-off:before {
+  content: "\f204";
+}
+.ion-tab-fa-toggle-on:before {
+  content: "\f205";
+}
+.ion-tab-fa-bicycle:before {
+  content: "\f206";
+}
+.ion-tab-fa-bus:before {
+  content: "\f207";
+}
+.ion-tab-fa-ioxhost:before {
+  content: "\f208";
+}
+.ion-tab-fa-angellist:before {
+  content: "\f209";
+}
+.ion-tab-fa-cc:before {
+  content: "\f20a";
+}
+.fa-shekel:before,
+.fa-sheqel:before,
+.ion-tab-fa-ils:before {
+  content: "\f20b";
+}
+.ion-tab-fa-meanpath:before {
+  content: "\f20c";
+}
+.ion-tab-fa-buysellads:before {
+  content: "\f20d";
+}
+.ion-tab-fa-connectdevelop:before {
+  content: "\f20e";
+}
+.ion-tab-fa-dashcube:before {
+  content: "\f210";
+}
+.ion-tab-fa-forumbee:before {
+  content: "\f211";
+}
+.ion-tab-fa-leanpub:before {
+  content: "\f212";
+}
+.ion-tab-fa-sellsy:before {
+  content: "\f213";
+}
+.ion-tab-fa-shirtsinbulk:before {
+  content: "\f214";
+}
+.ion-tab-fa-simplybuilt:before {
+  content: "\f215";
+}
+.ion-tab-fa-skyatlas:before {
+  content: "\f216";
+}
+.ion-tab-fa-cart-plus:before {
+  content: "\f217";
+}
+.ion-tab-fa-cart-arrow-down:before {
+  content: "\f218";
+}
+.ion-tab-fa-diamond:before {
+  content: "\f219";
+}
+.ion-tab-fa-ship:before {
+  content: "\f21a";
+}
+.ion-tab-fa-user-secret:before {
+  content: "\f21b";
+}
+.ion-tab-fa-motorcycle:before {
+  content: "\f21c";
+}
+.ion-tab-fa-street-view:before {
+  content: "\f21d";
+}
+.ion-tab-fa-heartbeat:before {
+  content: "\f21e";
+}
+.ion-tab-fa-venus:before {
+  content: "\f221";
+}
+.ion-tab-fa-mars:before {
+  content: "\f222";
+}
+.ion-tab-fa-mercury:before {
+  content: "\f223";
+}
+.fa-intersex:before,
+.ion-tab-fa-transgender:before {
+  content: "\f224";
+}
+.ion-tab-fa-transgender-alt:before {
+  content: "\f225";
+}
+.ion-tab-fa-venus-double:before {
+  content: "\f226";
+}
+.ion-tab-fa-mars-double:before {
+  content: "\f227";
+}
+.ion-tab-fa-venus-mars:before {
+  content: "\f228";
+}
+.ion-tab-fa-mars-stroke:before {
+  content: "\f229";
+}
+.ion-tab-fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+.ion-tab-fa-mars-stroke-h:before {
+  content: "\f22b";
+}
+.ion-tab-fa-neuter:before {
+  content: "\f22c";
+}
+.ion-tab-fa-genderless:before {
+  content: "\f22d";
+}
+.ion-tab-fa-facebook-official:before {
+  content: "\f230";
+}
+.ion-tab-fa-pinterest-p:before {
+  content: "\f231";
+}
+.ion-tab-fa-whatsapp:before {
+  content: "\f232";
+}
+.ion-tab-fa-server:before {
+  content: "\f233";
+}
+.ion-tab-fa-user-plus:before {
+  content: "\f234";
+}
+.ion-tab-fa-user-times:before {
+  content: "\f235";
+}
+.fa-hotel:before,
+.ion-tab-fa-bed:before {
+  content: "\f236";
+}
+.ion-tab-fa-viacoin:before {
+  content: "\f237";
+}
+.ion-tab-fa-train:before {
+  content: "\f238";
+}
+.ion-tab-fa-subway:before {
+  content: "\f239";
+}
+.ion-tab-fa-medium:before {
+  content: "\f23a";
+}
+.fa-yc:before,
+.ion-tab-fa-y-combinator:before {
+  content: "\f23b";
+}
+.ion-tab-fa-optin-monster:before {
+  content: "\f23c";
+}
+.ion-tab-fa-opencart:before {
+  content: "\f23d";
+}
+.ion-tab-fa-expeditedssl:before {
+  content: "\f23e";
+}
+.fa-battery-4:before,
+.ion-tab-fa-battery-full:before {
+  content: "\f240";
+}
+.fa-battery-3:before,
+.ion-tab-fa-battery-three-quarters:before {
+  content: "\f241";
+}
+.fa-battery-2:before,
+.ion-tab-fa-battery-half:before {
+  content: "\f242";
+}
+.fa-battery-1:before,
+.ion-tab-fa-battery-quarter:before {
+  content: "\f243";
+}
+.fa-battery-0:before,
+.ion-tab-fa-battery-empty:before {
+  content: "\f244";
+}
+.ion-tab-fa-mouse-pointer:before {
+  content: "\f245";
+}
+.ion-tab-fa-i-cursor:before {
+  content: "\f246";
+}
+.ion-tab-fa-object-group:before {
+  content: "\f247";
+}
+.ion-tab-fa-object-ungroup:before {
+  content: "\f248";
+}
+.ion-tab-fa-sticky-note:before {
+  content: "\f249";
+}
+.ion-tab-fa-sticky-note-o:before {
+  content: "\f24a";
+}
+.ion-tab-fa-cc-jcb:before {
+  content: "\f24b";
+}
+.ion-tab-fa-cc-diners-club:before {
+  content: "\f24c";
+}
+.ion-tab-fa-clone:before {
+  content: "\f24d";
+}
+.ion-tab-fa-balance-scale:before {
+  content: "\f24e";
+}
+.ion-tab-fa-hourglass-o:before {
+  content: "\f250";
+}
+.fa-hourglass-1:before,
+.ion-tab-fa-hourglass-start:before {
+  content: "\f251";
+}
+.fa-hourglass-2:before,
+.ion-tab-fa-hourglass-half:before {
+  content: "\f252";
+}
+.fa-hourglass-3:before,
+.ion-tab-fa-hourglass-end:before {
+  content: "\f253";
+}
+.ion-tab-fa-hourglass:before {
+  content: "\f254";
+}
+.fa-hand-grab-o:before,
+.ion-tab-fa-hand-rock-o:before {
+  content: "\f255";
+}
+.fa-hand-stop-o:before,
+.ion-tab-fa-hand-paper-o:before {
+  content: "\f256";
+}
+.ion-tab-fa-hand-scissors-o:before {
+  content: "\f257";
+}
+.ion-tab-fa-hand-lizard-o:before {
+  content: "\f258";
+}
+.ion-tab-fa-hand-spock-o:before {
+  content: "\f259";
+}
+.ion-tab-fa-hand-pointer-o:before {
+  content: "\f25a";
+}
+.ion-tab-fa-hand-peace-o:before {
+  content: "\f25b";
+}
+.ion-tab-fa-trademark:before {
+  content: "\f25c";
+}
+.ion-tab-fa-registered:before {
+  content: "\f25d";
+}
+.ion-tab-fa-creative-commons:before {
+  content: "\f25e";
+}
+.ion-tab-fa-gg:before {
+  content: "\f260";
+}
+.ion-tab-fa-gg-circle:before {
+  content: "\f261";
+}
+.ion-tab-fa-tripadvisor:before {
+  content: "\f262";
+}
+.ion-tab-fa-odnoklassniki:before {
+  content: "\f263";
+}
+.ion-tab-fa-odnoklassniki-square:before {
+  content: "\f264";
+}
+.ion-tab-fa-get-pocket:before {
+  content: "\f265";
+}
+.ion-tab-fa-wikipedia-w:before {
+  content: "\f266";
+}
+.ion-tab-fa-safari:before {
+  content: "\f267";
+}
+.ion-tab-fa-chrome:before {
+  content: "\f268";
+}
+.ion-tab-fa-firefox:before {
+  content: "\f269";
+}
+.ion-tab-fa-opera:before {
+  content: "\f26a";
+}
+.ion-tab-fa-internet-explorer:before {
+  content: "\f26b";
+}
+.fa-tv:before,
+.ion-tab-fa-television:before {
+  content: "\f26c";
+}
+.ion-tab-fa-contao:before {
+  content: "\f26d";
+}
+.ion-tab-fa-500px:before {
+  content: "\f26e";
+}
+.ion-tab-fa-amazon:before {
+  content: "\f270";
+}
+.ion-tab-fa-calendar-plus-o:before {
+  content: "\f271";
+}
+.ion-tab-fa-calendar-minus-o:before {
+  content: "\f272";
+}
+.ion-tab-fa-calendar-times-o:before {
+  content: "\f273";
+}
+.ion-tab-fa-calendar-check-o:before {
+  content: "\f274";
+}
+.ion-tab-fa-industry:before {
+  content: "\f275";
+}
+.ion-tab-fa-map-pin:before {
+  content: "\f276";
+}
+.ion-tab-fa-map-signs:before {
+  content: "\f277";
+}
+.ion-tab-fa-map-o:before {
+  content: "\f278";
+}
+.ion-tab-fa-map:before {
+  content: "\f279";
+}
+.ion-tab-fa-commenting:before {
+  content: "\f27a";
+}
+.ion-tab-fa-commenting-o:before {
+  content: "\f27b";
+}
+.ion-tab-fa-houzz:before {
+  content: "\f27c";
+}
+.ion-tab-fa-vimeo:before {
+  content: "\f27d";
+}
+.ion-tab-fa-black-tie:before {
+  content: "\f27e";
+}
+.ion-tab-fa-fonticons:before {
+  content: "\f280";
+}
+.ion-tab-fa-reddit-alien:before {
+  content: "\f281";
+}
+.ion-tab-fa-edge:before {
+  content: "\f282";
+}
+.ion-tab-fa-credit-card-alt:before {
+  content: "\f283";
+}
+.ion-tab-fa-codiepie:before {
+  content: "\f284";
+}
+.ion-tab-fa-modx:before {
+  content: "\f285";
+}
+.ion-tab-fa-fort-awesome:before {
+  content: "\f286";
+}
+.ion-tab-fa-usb:before {
+  content: "\f287";
+}
+.ion-tab-fa-product-hunt:before {
+  content: "\f288";
+}
+.ion-tab-fa-mixcloud:before {
+  content: "\f289";
+}
+.ion-tab-fa-scribd:before {
+  content: "\f28a";
+}
+.ion-tab-fa-pause-circle:before {
+  content: "\f28b";
+}
+.ion-tab-fa-pause-circle-o:before {
+  content: "\f28c";
+}
+.ion-tab-fa-stop-circle:before {
+  content: "\f28d";
+}
+.ion-tab-fa-stop-circle-o:before {
+  content: "\f28e";
+}
+.ion-tab-fa-shopping-bag:before {
+  content: "\f290";
+}
+.ion-tab-fa-shopping-basket:before {
+  content: "\f291";
+}
+.ion-tab-fa-hashtag:before {
+  content: "\f292";
+}
+.ion-tab-fa-bluetooth:before {
+  content: "\f293";
+}
+.ion-tab-fa-bluetooth-b:before {
+  content: "\f294";
+}
+.ion-tab-fa-percent:before {
+  content: "\f295";
+}

--- a/font-awesome-ionic-tabs.css
+++ b/font-awesome-ionic-tabs.css
@@ -27,7 +27,6 @@ To add more icons:
 [class*=" ion-tab-fa-"]:before {
   display: inline-block;
   font-family: "FontAwesome";
-  font-size: 72%;
   speak: none;
   font-style: normal;
   font-weight: normal;

--- a/font-awesome-ionic-tabs.css
+++ b/font-awesome-ionic-tabs.css
@@ -24,17 +24,7 @@ To add more icons:
 * Name your style identical to the font awesome style, but prefix with "ion-tab-"
 * Add in two places (CSS description at top and the specific content: with the unicode) */
 
-.ion-tab-fa-anchor:before,
-.ion-tab-fa-tags:before,
-.ion-tab-fa-list:before, 
-.ion-tab-fa-user:before,
-.ion-tab-fa-users:before,
-.ion-tab-fa-comments:before,
-.ion-tab-fa-cog:before,
-.ion-tab-fa-gear:before,
-.ion-tab-fa-calendar-o:before,
-.ion-tab-fa-calendar:before,
-.ion-tab-fa-info:before {
+[class*=" ion-tab-fa-"]:before {
   display: inline-block;
   font-family: "FontAwesome";
   font-size: 72%;


### PR DESCRIPTION
Simplified the CSS code so any element prefixed with the ﻿`ion-tab-fa-` will pick up the common CSS.  This means new icons only need to be added once.
Removed font size override as this seemed to be an app-specific feature (?)
Added all the FA icons in FA 4.5.0
